### PR TITLE
Add optional error handler mappings.

### DIFF
--- a/src/lib/hooks/useErrorHandler.test.tsx
+++ b/src/lib/hooks/useErrorHandler.test.tsx
@@ -121,3 +121,207 @@ test("additional error details are available to be rendered", async () => {
     await screen.findByText("the message");
     await screen.findByText("the sub-message");
 });
+
+describe("Handler Level Error mapping", () => {
+    it("can map error messages from error objects at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError>();
+            const performAction = () => errorHandler(Promise.reject({
+                message: "the message",
+                subMessage: "the sub-message"
+            }), {
+                mapMessage: message => `Prefix: ${message}`
+            });
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.message}</b>
+                        <span>{error.subMessage}</span>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Prefix: the message");
+        screen.getByText("the sub-message");
+    });
+
+    it("can map error messages from error strings at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError>();
+            const performAction = () => errorHandler(Promise.reject("the message"), {
+                mapMessage: message => `Prefix: ${message}`
+            });
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.message}</b>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Prefix: the message");
+    });
+
+    it("can map error objects from error objects at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError & { view?: any }>();
+            const performAction = () => errorHandler(Promise.reject({
+                message: "the message",
+                subMessage: "the sub-message"
+            }), {
+                mapError: error => ({
+                    ...error,
+                    view: <span>Special view for {error.message}</span>
+                })
+            });
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.view || error.message}</b>
+                        <span>{error.subMessage}</span>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Special view for the message");
+        screen.findByText("the sub-message");
+    });
+
+    it("can map error objects from error strings at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError & { view?: any }>();
+            const performAction = () => errorHandler(Promise.reject("the message"), {
+                mapError: error => ({
+                    ...error,
+                    view: <span>Special view for {error.message}</span>
+                })
+            });
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.view || error.message}</b>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Special view for the message");
+    });
+});
+
+describe("Hook Level Error mapping", () => {
+    it("can map error messages from error objects at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError>({
+                mapMessage: message => `Prefix: ${message}`
+            });
+            const performAction = () => errorHandler(Promise.reject({
+                message: "the message",
+                subMessage: "the sub-message"
+            }));
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.message}</b>
+                        <span>{error.subMessage}</span>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Prefix: the message");
+        screen.getByText("the sub-message");
+    });
+
+    it("can map error messages from error strings at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError>({
+                mapMessage: message => `Prefix: ${message}`
+            });
+            const performAction = () => errorHandler(Promise.reject("the message"));
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.message}</b>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Prefix: the message");
+    });
+
+    it("can map error objects from error objects at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError & { view?: any }>({
+                mapError: error => ({
+                    ...error,
+                    view: <span>Special view for {error.message}</span>
+                })
+            });
+            const performAction = () => errorHandler(Promise.reject({
+                message: "the message",
+                subMessage: "the sub-message"
+            }));
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.view || error.message}</b>
+                        <span>{error.subMessage}</span>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Special view for the message");
+        screen.findByText("the sub-message");
+    });
+
+    it("can map error objects from error strings at the handler level", async () => {
+        const App = () => {
+            const { errorHandler, errors } = useErrorHandler<SubError & { view?: any }>({
+                mapError: error => ({
+                    ...error,
+                    view: <span>Special view for {error.message}</span>
+                })
+            });
+            const performAction = () => errorHandler(Promise.reject("the message"));
+
+            return <>
+                <ul>
+                    {errors.map(error => <li key={error.message}>
+                        <b>{error.view || error.message}</b>
+                    </li>)}
+                </ul>
+                <button onClick={performAction}>Invoke</button>
+            </>;
+        };
+        render(<App />);
+        screen.getByText("Invoke").click();
+        await screen.findByText("Special view for the message");
+    });
+});

--- a/src/lib/hooks/useErrorHandler.ts
+++ b/src/lib/hooks/useErrorHandler.ts
@@ -1,25 +1,37 @@
 import { useMountedOnlyState } from "./useMountedOnlyState";
 
+interface ErrorMessage {
+    message: string;
+}
+
 type Errors<TError> = {
     [key: string]: TError
 }
 
+type ErrorMappings<TError> = {
+    mapMessage?: (currentMessage: string) => string,
+    mapError?: (error: TError) => TError
+}
+
 type HookResult<TError> = {
-    errorHandler: <T>(operation: Promise<T>) => Promise<T | undefined>,
+    errorHandler: <T>(operation: Promise<T>, mappings?: ErrorMappings<TError>) => Promise<T | undefined>,
     errors: Array<TError>,
     clearError: (error: TError) => void
 };
 
-export function useErrorHandler<TError extends { message: string }>(): HookResult<TError> {
+export function useErrorHandler<TError extends ErrorMessage>(hookMappings?: ErrorMappings<TError>): HookResult<TError> {
     const [errors, setErrors] = useMountedOnlyState<Errors<TError>>({});
 
     return {
-        errorHandler: async <T>(operation: Promise<T>) => {
+        errorHandler: async (operation, handlerMappings) => {
             try {
                 return await operation;
             }
             catch (error) {
-                setErrors(updatedErrorsWith<TError>(error));
+                setErrors(updatedErrorsWith<TError>(mappedErrorFrom<TError>(error, {
+                    ...hookMappings,
+                    ...handlerMappings
+                })));
             }
         },
         errors: Object.values(errors),
@@ -30,12 +42,24 @@ export function useErrorHandler<TError extends { message: string }>(): HookResul
     };
 }
 
-function updatedErrorsWith<TError extends { message: string; }>(error: any) {
-    return (currentErrors: Errors<TError>) => {
-        const message = error?.message || error;
-        return {
-            ...currentErrors,
-            [message]: error instanceof Object ? error : { message }
-        };
+function mappedErrorFrom<TError extends ErrorMessage>(error: any, mappings: ErrorMappings<TError> | undefined) {
+    const errorObject = error instanceof Object ? error : { message: error };
+    const messageMappedError: TError = {
+        ...errorObject,
+        message: mappings?.mapMessage
+            ? mappings.mapMessage(errorObject.message)
+            : errorObject.message
     };
+    const mappedError = mappings?.mapError
+        ? mappings.mapError(messageMappedError)
+        : messageMappedError;
+
+    return mappedError;
+}
+
+function updatedErrorsWith<TError extends ErrorMessage>(error: TError) {
+    return (currentErrors: Errors<TError>): Errors<TError> => ({
+        ...currentErrors,
+        [error.message]: error
+    });
 }


### PR DESCRIPTION
- [X] Implement

- [x] Investigate trade-offs

- [ ] Merge

- [ ] Deploy

Current thoughts on trade-offs:

- This increase in size & complexity may not be worth the value.

- Is there value in this mapping from errors to other errors considering the application will still need to map the error to a component (render the error).

- Does this mapping make rendering errors easier?

- Does this mapping belong in the component(s) that render errors?