### PR TITLE
Managed context hooks can’t support local and contexts states

### DIFF
--- a/src/lib/createManagedContext.test.tsx
+++ b/src/lib/createManagedContext.test.tsx
@@ -74,12 +74,3 @@ test("using managed context that's shared by two components in the same provider
     expect(screen.getAllByText("First Name: John")).toHaveLength(2);
     expect(screen.getAllByText("Last Name: Doe")).toHaveLength(2);
 });
-
-test("using managed context without a context provider only changes the local state but does work", () => {
-    render(<EditUser />);
-
-    fireEvent.change(screen.getByLabelText("First Name"), { target: { value: "John" } });
-    fireEvent.change(screen.getByLabelText("Last Name"), { target: { value: "Doe" } });
-    expect(screen.getByLabelText("First Name")).toHaveValue("John");
-    expect(screen.getByLabelText("Last Name")).toHaveValue("Doe");
-});

--- a/src/lib/createManagedContext.tsx
+++ b/src/lib/createManagedContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from "react";
 
 type ContextProvider = ({ children }: any) => JSX.Element;
 
-type UseManagedStateHook<T> = () => T;
+type UseManagedStateHook<T> = () => T | undefined;
 
 export function createManagedContext<T>(
   useManagedState: UseManagedStateHook<T>

--- a/src/lib/createManagedContext.tsx
+++ b/src/lib/createManagedContext.tsx
@@ -13,9 +13,7 @@ export function createManagedContext<T>(
     return <Context.Provider value={managedState}>{children}</Context.Provider>;
   };
   const useManagedContext = () => {
-    const contextState = useContext(Context);
-    const localState = useManagedState();
-    return contextState || localState;
+    return useContext(Context);
   };
 
   return [ContextProvider, useManagedContext];


### PR DESCRIPTION
Because it would cause lifecycle to duplicate.